### PR TITLE
Updated Travis CI Golang testing versions for 2020.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: go
 
 go:
+  # n.b. For golang release history, see https://golang.org/doc/devel/release.html
   - tip
-  - "1.10"
-  - 1.9
-  - 1.8
-  - 1.7
-  - 1.6
-  - 1.5
-  - 1.4
+  - "1.13.8"
+  - "1.12.17"
+  - "1.11.13"
+  - "1.10.8"
+  - "1.9.7"
 
 notifications:
   email:

--- a/resolve_local_interface.go
+++ b/resolve_local_interface.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 var (


### PR DESCRIPTION
- Added Go versions 1.9.7, 1.10.8, 1.11.13, 1.12.17, and 1.13.8.
- Dropped Go versions 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, and 1.10.